### PR TITLE
Add OpenRouter stealth/ox-alpha as a compliance LLM-judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,19 @@ uv run scripts/evaluate_responses.py results/<run_dir>/ --force    # Re-evaluate
 ```
 
 The compliance reviewer uses Gemini 3.6 Flash with high thinking by default.
-To use GPT-5.6 Terra with high reasoning instead, set these values in the
-project-local `.env` file:
+To use GPT-5.6 Terra with high reasoning instead, or an OpenRouter model such
+as stealth/ox-alpha, set these values in the project-local `.env` file:
 
 ```bash
 COMPLIANCE_PROVIDER=openai
 COMPLIANCE_MODEL=gpt-5.6-terra
 COMPLIANCE_REASONING_EFFORT=high
+```
+
+```bash
+COMPLIANCE_PROVIDER=openrouter
+COMPLIANCE_MODEL=stealth/ox-alpha
+COMPLIANCE_REASONING_EFFORT=max
 ```
 
 The selected provider requires its corresponding API key. Missing keys, API

--- a/scripts/evaluate_responses.py
+++ b/scripts/evaluate_responses.py
@@ -27,6 +27,19 @@ from pathlib import Path
 _project_root = Path(__file__).parent.parent
 from dotenv import load_dotenv
 load_dotenv(_project_root / ".env")
+for _key in (
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "COMPLIANCE_PROVIDER",
+    "COMPLIANCE_MODEL",
+    "COMPLIANCE_REASONING_EFFORT",
+):
+    _value = os.getenv(_key)
+    if _value:
+        os.environ[_key] = _value.strip()
 if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
     os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
 

--- a/scripts/evaluator/compliance.py
+++ b/scripts/evaluator/compliance.py
@@ -3,7 +3,8 @@
 Verifies that model solutions use genuine closed-form expressions rather than
 forbidden numerical techniques (numerical integration, truncated series,
 numerical root-finding, etc.). Uses Gemini 3.6 Flash with high thinking by
-default, with GPT-5.6 Terra at high reasoning available as an alternative.
+default. GPT-5.6 Terra (OpenAI) and OpenRouter models such as stealth/ox-alpha
+are available as alternative reviewers.
 """
 
 import json
@@ -87,6 +88,19 @@ COMPLIANCE_MODEL = "gemini-3.6-flash"
 COMPLIANCE_THINKING_LEVEL = types.ThinkingLevel.HIGH
 OPENAI_COMPLIANCE_MODEL = "gpt-5.6-terra"
 OPENAI_COMPLIANCE_REASONING_EFFORT = "high"
+OPENROUTER_COMPLIANCE_MODEL = "stealth/ox-alpha"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+_PROVIDER_DEFAULT_MODELS = {
+    "gemini": COMPLIANCE_MODEL,
+    "openai": OPENAI_COMPLIANCE_MODEL,
+    "openrouter": OPENROUTER_COMPLIANCE_MODEL,
+}
+_PROVIDER_API_KEYS = {
+    "gemini": "GOOGLE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
 
 _COMPLIANCE_RESPONSE_SCHEMA = {
     "type": "object",
@@ -106,18 +120,23 @@ def _reviewer_config() -> tuple[str, str]:
     ).strip().lower()
     if provider == "google":
         provider = "gemini"
-    if provider == "gemini":
-        default_model = COMPLIANCE_MODEL
-    elif provider == "openai":
-        default_model = OPENAI_COMPLIANCE_MODEL
-    else:
+    if provider not in _PROVIDER_DEFAULT_MODELS:
         raise ValueError(
-            "COMPLIANCE_PROVIDER must be either 'gemini' or 'openai'"
+            "COMPLIANCE_PROVIDER must be one of 'gemini', 'openai', or 'openrouter'"
         )
-    model = os.environ.get("COMPLIANCE_MODEL", default_model).strip()
+    model = os.environ.get(
+        "COMPLIANCE_MODEL", _PROVIDER_DEFAULT_MODELS[provider]
+    ).strip()
     if not model:
         raise ValueError("COMPLIANCE_MODEL must not be empty")
     return provider, model
+
+
+def _reasoning_effort() -> str:
+    return os.environ.get(
+        "COMPLIANCE_REASONING_EFFORT",
+        OPENAI_COMPLIANCE_REASONING_EFFORT,
+    ).strip().lower()
 
 
 def _parse_compliance_response(
@@ -155,6 +174,79 @@ def _parse_compliance_response(
     )
 
 
+def _gemini_compliance_text(prompt: str, model: str) -> str:
+    client = genai.Client()
+    response = client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(
+                thinking_level=COMPLIANCE_THINKING_LEVEL
+            ),
+            response_mime_type="application/json",
+            response_schema=_COMPLIANCE_RESPONSE_SCHEMA,
+        ),
+    )
+    return response.text
+
+
+def _openai_compliance_text(prompt: str, model: str) -> str:
+    client = openai.OpenAI(timeout=10 * 60)
+    response = client.responses.create(
+        model=model,
+        input=prompt,
+        reasoning={"effort": _reasoning_effort()},
+        max_output_tokens=2000,
+        store=False,
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "compliance_result",
+                "strict": True,
+                "schema": _COMPLIANCE_RESPONSE_SCHEMA,
+            },
+        },
+    )
+    return response.output_text
+
+
+def _openrouter_compliance_text(prompt: str, model: str) -> str:
+    """Call OpenRouter chat completions for a compliance verdict.
+
+    Uses the same chat-completions + extra_body reasoning path as
+    run_benchmark.py. Structured JSON is requested in the prompt; the
+    existing parser already accepts markdown-fenced objects. max_tokens is
+    larger than the OpenAI reviewer because reasoning tokens share the
+    completion budget on many OpenRouter models.
+    """
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY environment variable is not set")
+
+    reasoning_effort = _reasoning_effort()
+    client = openai.OpenAI(
+        base_url=OPENROUTER_BASE_URL,
+        api_key=api_key,
+        timeout=10 * 60,
+    )
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=32000,
+        extra_body={
+            "reasoning": {
+                "enabled": reasoning_effort != "none",
+                "effort": reasoning_effort,
+            }
+        },
+    )
+    message = response.choices[0].message
+    text = message.content
+    if not text:
+        raise ValueError("OpenRouter reviewer returned an empty message content")
+    return text
+
+
 def _single_compliance_check(
     prompt: str,
     provider: str,
@@ -163,41 +255,11 @@ def _single_compliance_check(
     """Run a single compliance check against the configured reviewer."""
     try:
         if provider == "gemini":
-            client = genai.Client()
-            response = client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    thinking_config=types.ThinkingConfig(
-                        thinking_level=COMPLIANCE_THINKING_LEVEL
-                    ),
-                    response_mime_type="application/json",
-                    response_schema=_COMPLIANCE_RESPONSE_SCHEMA,
-                ),
-            )
-            text = response.text
+            text = _gemini_compliance_text(prompt, model)
+        elif provider == "openrouter":
+            text = _openrouter_compliance_text(prompt, model)
         else:
-            reasoning_effort = os.environ.get(
-                "COMPLIANCE_REASONING_EFFORT",
-                OPENAI_COMPLIANCE_REASONING_EFFORT,
-            ).strip().lower()
-            client = openai.OpenAI(timeout=10 * 60)
-            response = client.responses.create(
-                model=model,
-                input=prompt,
-                reasoning={"effort": reasoning_effort},
-                max_output_tokens=2000,
-                store=False,
-                text={
-                    "format": {
-                        "type": "json_schema",
-                        "name": "compliance_result",
-                        "strict": True,
-                        "schema": _COMPLIANCE_RESPONSE_SCHEMA,
-                    },
-                },
-            )
-            text = response.output_text
+            text = _openai_compliance_text(prompt, model)
         return _parse_compliance_response(text, provider, model)
     except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
         return ComplianceResult(
@@ -251,7 +313,7 @@ def check_solution_compliance(
             reason=f"Compliance check indeterminate due to configuration error: {e}",
         )
 
-    api_key_name = "GOOGLE_API_KEY" if provider == "gemini" else "OPENAI_API_KEY"
+    api_key_name = _PROVIDER_API_KEYS[provider]
     if not os.environ.get(api_key_name):
         return ComplianceResult(
             compliant=None,

--- a/scripts/evaluator/compliance.py
+++ b/scripts/evaluator/compliance.py
@@ -219,7 +219,7 @@ def _openrouter_compliance_text(prompt: str, model: str) -> str:
     larger than the OpenAI reviewer because reasoning tokens share the
     completion budget on many OpenRouter models.
     """
-    api_key = os.getenv("OPENROUTER_API_KEY")
+    api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
     if not api_key:
         raise ValueError("OPENROUTER_API_KEY environment variable is not set")
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -52,6 +52,19 @@ from dotenv import load_dotenv
 _project_root = Path(__file__).parent.parent
 load_dotenv(_project_root / ".env")
 
+# Secrets injected via env files sometimes include a trailing newline, which
+# httpx rejects as an illegal Authorization header value.
+for _key in (
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_API_KEY",
+):
+    _value = os.getenv(_key)
+    if _value:
+        os.environ[_key] = _value.strip()
+
 # Handle GEMINI_API_KEY -> GOOGLE_API_KEY mapping
 if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
     os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
@@ -344,7 +357,7 @@ def call_openrouter(
 
     Returns dict with 'content' and optional 'reasoning_details'.
     """
-    api_key = os.getenv("OPENROUTER_API_KEY")
+    api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
     if not api_key:
         raise ValueError("OPENROUTER_API_KEY environment variable is not set")
 
@@ -476,6 +489,40 @@ def call_anthropic(
     return result
 
 
+def check_openrouter_model_available(model: str) -> None:
+    """Fail fast if the OpenRouter account cannot route to the requested model."""
+    api_key = (os.getenv("OPENROUTER_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY environment variable is not set")
+
+    # /models is the public catalog. /models/user is filtered by this
+    # account's privacy settings and guardrails.
+    try:
+        import httpx
+
+        response = httpx.get(
+            "https://openrouter.ai/api/v1/models/user",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        available = {item.get("id") for item in response.json().get("data", [])}
+    except Exception as exc:
+        print(f"Warning: could not list account-visible OpenRouter models: {exc}")
+        return
+
+    if model in available:
+        return
+
+    raise RuntimeError(
+        f"OpenRouter model {model!r} is not available under this API key's "
+        "guardrail/data-policy settings. The catalog lists the model, but "
+        "/models/user does not. Enable the Stealth/free-model data-retention "
+        "toggles at https://openrouter.ai/settings/privacy (and accept the "
+        "Stealth Model Terms), or use a key whose guardrails allow this model."
+    )
+
+
 def create_run_folder(provider: str, model: str, base_dir: Path) -> Path:
     """Create a timestamped output folder for the run."""
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -502,6 +549,25 @@ def get_completed_problems(responses_path: Path) -> set[str]:
     return completed
 
 
+def _is_retryable_api_error(exc: Exception) -> bool:
+    """Retry transient transport/server failures, not client configuration errors."""
+    if isinstance(
+        exc,
+        (
+            openai.NotFoundError,
+            openai.AuthenticationError,
+            openai.PermissionDeniedError,
+            openai.BadRequestError,
+            anthropic.BadRequestError,
+            anthropic.AuthenticationError,
+            anthropic.PermissionDeniedError,
+            anthropic.NotFoundError,
+        ),
+    ):
+        return False
+    return True
+
+
 def retry_api_call(fn, *args, max_retries=3, **kwargs):
     """Retry an API call with exponential backoff on transient errors."""
     from google.genai import errors as genai_errors
@@ -523,7 +589,7 @@ def retry_api_call(fn, *args, max_retries=3, **kwargs):
             TimeoutError,
         ) as e:
             last_exception = e
-            if attempt < max_retries:
+            if attempt < max_retries and _is_retryable_api_error(e):
                 delay = backoff_seconds[min(attempt, len(backoff_seconds) - 1)]
                 print(f"    ⚠ API error (attempt {attempt + 1}/{max_retries + 1}): "
                       f"{type(e).__name__}: {str(e)[:80]}")
@@ -820,6 +886,13 @@ def main():
         print(str(exc), file=sys.stderr)
         sys.exit(1)
     api_timeout_seconds = None if api_timeout_minutes is None else api_timeout_minutes * 60
+
+    if args.provider == "openrouter" and not args.debug:
+        try:
+            check_openrouter_model_available(args.model)
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
 
     # Paths
     project_root = Path(__file__).parent.parent

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -16,9 +16,18 @@ from evaluator.compliance import (
     COMPLIANCE_MODEL,
     COMPLIANCE_THINKING_LEVEL,
     DEFAULT_COMPLIANCE_ROUNDS,
+    OPENROUTER_COMPLIANCE_MODEL,
     check_solution_compliance,
     ComplianceResult,
 )
+
+
+def _mock_openrouter_response(text: str):
+    """Create a mock OpenRouter chat-completions response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = text
+    return mock_response
 
 
 def _mock_genai_response(text: str):
@@ -149,6 +158,52 @@ def test_no_strict_majority_is_indeterminate(mock_client_cls):
     assert "no strict majority" in result.reason.lower()
     assert "1/3 compliant" in result.reason
     assert "2/3 indeterminate" in result.reason
+
+
+@patch.dict(
+    os.environ,
+    {
+        "COMPLIANCE_PROVIDER": "openrouter",
+        "COMPLIANCE_MODEL": "stealth/ox-alpha",
+        "COMPLIANCE_REASONING_EFFORT": "max",
+        "OPENROUTER_API_KEY": "test-openrouter-key",
+    },
+    clear=True,
+)
+@patch("evaluator.compliance.openai.OpenAI")
+def test_openrouter_reviewer_uses_chat_completions(mock_openai_cls):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_openrouter_response(
+        '{"compliant": true, "reason": "independent closed-form expression"}'
+    )
+    mock_openai_cls.return_value = mock_client
+
+    result = check_solution_compliance("def proposed_solution():\n    return mp.pi")
+    assert result.compliant is True
+    assert result.provider == "openrouter"
+    assert result.model == "stealth/ox-alpha"
+    mock_openai_cls.assert_called_with(
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-openrouter-key",
+        timeout=10 * 60,
+    )
+    call = mock_client.chat.completions.create.call_args
+    assert call.kwargs["model"] == OPENROUTER_COMPLIANCE_MODEL == "stealth/ox-alpha"
+    assert call.kwargs["extra_body"]["reasoning"]["effort"] == "max"
+    assert call.kwargs["extra_body"]["reasoning"]["enabled"] is True
+
+
+@patch.dict(
+    os.environ,
+    {"COMPLIANCE_PROVIDER": "openrouter"},
+    clear=True,
+)
+def test_missing_openrouter_api_key_is_indeterminate():
+    result = check_solution_compliance("def proposed_solution():\n    return mp.pi")
+    assert result.compliant is None
+    assert result.status == "indeterminate"
+    assert "openrouter_api_key is not set" in result.reason.lower()
+    assert result.model == OPENROUTER_COMPLIANCE_MODEL
 
 
 def test_default_compliance_review_uses_five_rounds():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Allows HorizonMath evaluation to use OpenRouter models (default `stealth/ox-alpha`) as the closed-form compliance reviewer, instead of only Gemini 3.6 Flash or GPT-5.6 Terra.

```bash
COMPLIANCE_PROVIDER=openrouter
COMPLIANCE_MODEL=stealth/ox-alpha
COMPLIANCE_REASONING_EFFORT=max
uv run scripts/evaluate_responses.py results/<run_dir>/
```

Also strips trailing whitespace from injected API keys (a newline on `OPENROUTER_API_KEY` was causing httpx `Illegal header value` / `APIConnectionError`) and fails fast when an OpenRouter model is hidden by account privacy/guardrails.

This run executes HorizonMath against `stealth/ox-alpha` on problems 0–2 (`w4`, `w5`, `w6` Watson integrals) with `--reasoning-effort max --parallel 3`, then evaluates those responses with ox-alpha as the judge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e1bbb00-5264-45ce-8072-87921e9579c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e1bbb00-5264-45ce-8072-87921e9579c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

