### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+HorizonMath is a Python math-benchmark project. Its core product is the **automatic
+verification pipeline** that scores LLM-generated math solutions. There is no GUI and
+no web service — everything runs as CLI scripts. See `README.md` for the full command
+reference; the notes below only capture non-obvious, durable gotchas.
+
+### Environment / tooling
+- Package manager is **uv** (installed at `~/.local/bin/uv`, already on `PATH` via
+  `~/.profile`/`~/.bashrc`). Dependencies come from `pyproject.toml` + `uv.lock`; the
+  startup update script runs `uv sync`. Always invoke project code with `uv run ...`.
+- Python is pinned to 3.12 (`.python-version`).
+- There is **no linter** configured (no ruff/flake8/black/pylint). "Lint" is not a step
+  in this repo; don't invent one.
+
+### Testing
+- Run the suite with `uv run pytest` (43 tests, ~5–10s). `tests/test_ramsey_baseline.py`
+  is a standalone script, not a pytest module, so pytest does not collect it.
+
+### Running the product
+- Single solution: `uv run python scripts/evaluate.py --llm-output <file> --problem-id <id>`
+  (mode auto-detected). Numeric (`ground_truth_computable`) and benchmark
+  (`benchmark_best_known`) evaluation need **no API key**.
+- Two-phase benchmark: `scripts/run_benchmark.py` (Phase 1, generate) then
+  `scripts/evaluate_responses.py <run_dir>` (Phase 2, evaluate). Only Phase 1 and the
+  compliance reviewer call external model APIs. Results land in `results/` (gitignored).
+
+### Non-obvious gotchas
+- **Numeric solutions must return the value as a string (or high-precision), not a bare
+  Python `float`.** A `float` only preserves ~16 digits, so it fails the default
+  20-digit match threshold. Returning the digits as a string passes (e.g. 38/38 digits).
+- **Model API keys must be stored WITHOUT trailing whitespace/newline.** A trailing
+  `\n` in `OPENROUTER_API_KEY` (or `OPENAI_API_KEY`, etc.) corrupts the `Authorization`
+  header: OpenRouter returns `{"error":"JSON parsing failed","code":400}` and the OpenAI
+  SDK raises `APIConnectionError: Connection error`. `run_benchmark.py` reads the key raw
+  (`os.getenv`) and does not strip it, so the secret itself must be clean. Provider keys
+  the runner understands: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`,
+  `ANTHROPIC_API_KEY`.
+- A few validators (elliptic-curve rank, inverse-Galois) shell out to **SageMath**, which
+  is not installed here. They report a "sage not found" failure and honor `SAGE_CMD` if
+  you install Sage separately. The rest of the evaluation pipeline works without Sage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the HorizonMath development environment for Cursor Cloud agents and documents durable, non-obvious learnings. No application code was changed — this only adds `AGENTS.md`.

## Environment

- Package manager: **uv** (`uv sync` installs all deps from `pyproject.toml` + `uv.lock`, including torch, fpylll, cysignals, snappy).
- Python 3.12 (pinned via `.python-version`).
- No linter is configured in this repo (no ruff/flake8/black).
- Startup update script: install `uv` if missing, then `uv sync`.

## Verified working

| Step | Command | Result |
|---|---|---|
| Tests | `uv run pytest` | 43 passed |
| Evaluate (numeric) | `uv run python scripts/evaluate.py --llm-output <f> --problem-index 0` | PASS, 38/38 digits |
| Evaluate (benchmark/validator) | `uv run python scripts/evaluate.py ... --mode benchmark` | validator + baseline comparison ran |
| Generate (Phase 1) | `uv run scripts/run_benchmark.py --problem ... --provider openrouter` | live model response saved |
| Evaluate responses (Phase 2) | `uv run scripts/evaluate_responses.py <run_dir>` | generated response scored |

## Notable finding

The `OPENROUTER_API_KEY` secret contains a trailing newline, which corrupts the `Authorization` header (OpenRouter returns `JSON parsing failed`; the OpenAI SDK raises `APIConnectionError`). The generation phase only works once the key is stored without trailing whitespace. This and other gotchas are documented in `AGENTS.md`.

[Setup and evaluation demo](https://cursor.com/agents/bc-fa7563dd-44fd-4046-9828-be49517510f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_and_evaluation_demo.log)
[Two-phase pipeline demo](https://cursor.com/agents/bc-fa7563dd-44fd-4046-9828-be49517510f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgenerate_evaluate_pipeline_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa7563dd-44fd-4046-9828-be49517510f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa7563dd-44fd-4046-9828-be49517510f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

